### PR TITLE
コマンドの分離を実施

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,28 @@ Sample of Kotlin on Spring Boot.
 
 ### Build
 
-`gradle build` is deprecate. Instead of `gradlew build -x runKtlintCheckOverMainSourceSet -x test`
+`gradlew build` is deprecate. Instead of `gradlew build -x runKtlintCheckOverMainSourceSet -x test`
 Cause: gradle-ktlint has bug.
 Issue: https://github.com/JLLeitschuh/ktlint-gradle/issues/579
 Note:
-To save time, test step excluded from the build task.
+To save time, test step excluded from the build task.  
 If other tasks also fail related to ktlint, use the -x option to exclude them.
 
 ```shell
 # Build
 gradlew build -x runKtlintCheckOverMainSourceSet -x test
+```
+
+### Formatter
+
+```shell
 # Set kotlin formatter for IntelliJ
 gradlew ktlintApplyToIdea
+```
+
+###  Up Container
+
+```bash
 # Init datasource
 docker-compose -f docker-compose.yaml -p kotlin-on-spring-boot up -d
 ```
@@ -49,3 +59,4 @@ docker-compose down
 ## Swagger
 
 [Swagger-UI](http://localhost:8080/rami/swagger-ui/index.html)
+ß

--- a/README.md
+++ b/README.md
@@ -16,21 +16,22 @@ To save time, test step excluded from the build task.
 If other tasks also fail related to ktlint, use the -x option to exclude them.
 
 ```shell
-# Build
 gradlew build -x runKtlintCheckOverMainSourceSet -x test
 ```
 
 ### Formatter
 
+Set kotlin formatter for IntelliJ.
+
 ```shell
-# Set kotlin formatter for IntelliJ
 gradlew ktlintApplyToIdea
 ```
 
 ###  Up Container
 
+Init datasource.
+
 ```bash
-# Init datasource
 docker-compose -f docker-compose.yaml -p kotlin-on-spring-boot up -d
 ```
 
@@ -58,5 +59,6 @@ docker-compose down
 
 ## Swagger
 
+### Local
+
 [Swagger-UI](http://localhost:8080/rami/swagger-ui/index.html)
-ß


### PR DESCRIPTION
# ISSUE

- https://github.com/rami2076/kotlin-on-spring-boot/issues/10

# 対応内容
Readme.mdのコマンドを分離し実行しやすく変更．

# 動作確認
コマンドが分離できていることを確認
https://github.com/rami2076/kotlin-on-spring-boot/blob/ec17d8833be43b93aa725703d5f02ed3641674c3/README.md
<img width="200" alt="image" src="https://github.com/rami2076/kotlin-on-spring-boot/assets/4788466/da176dd1-cf79-46d9-a5a5-623b646e0fbc">



# レビューコメントについて

| ラベル  | 意味                          | 意図                                |
|------|-----------------------------|-----------------------------------|
| Q    | 質問 (Question)               | 質問。相手は回答が必要                       |
| FYI  | 参考まで (For your information) | 参考までに共有。アクションは不要 (確認事項を残す場合などに使用) |
| NITS | あら捜し (Nitpick)              | 重箱の隅をつつく提案。無視しても良い                |
| NR   | お手すきで (No rush)             | 今やらなくて良いが、将来的には解決したい提案。タスク化や修正を検討 |
| IMO  | 提案 (In my opinion)          | 個人的な見解や、軽微な提案。タスク化や修正を検討          |
| MUST | 必須 (Must)                   | これを直さないと承認できない。修正を検討              |

https://zenn.dev/hacobell_dev/articles/code-review-comment-prefix

# その他
