### PR TITLE
dependabot.ymlを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# ISSUE

- https://github.com/rami2076/kotlin-on-spring-boot/issues/53

# 対応内容
dependabotを入れて依存するライブラリの更新があった場合にPRを投げてもらうようにしましたが、
一旦検証のためインターバルを一日にしています。

状況をみてインターバルを変更するのとどんな風に動くのかを確認するためのPRです。

# 動作確認
動作確認は後日行う。

# レビューコメントについて

| ラベル  | 意味                          | 意図                                |
|------|-----------------------------|-----------------------------------|
| Q    | 質問 (Question)               | 質問。相手は回答が必要                       |
| FYI  | 参考まで (For your information) | 参考までに共有。アクションは不要 (確認事項を残す場合などに使用) |
| NITS | あら捜し (Nitpick)              | 重箱の隅をつつく提案。無視しても良い                |
| NR   | お手すきで (No rush)             | 今やらなくて良いが、将来的には解決したい提案。タスク化や修正を検討 |
| IMO  | 提案 (In my opinion)          | 個人的な見解や、軽微な提案。タスク化や修正を検討          |
| MUST | 必須 (Must)                   | これを直さないと承認できない。修正を検討              |

https://zenn.dev/hacobell_dev/articles/code-review-comment-prefix

# その他
https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file